### PR TITLE
feat(folder-templates): 添加忽略文件夹配置与判断

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -168,6 +168,12 @@ const translations: BaseMessage = {
 					placeholder: "Please enable core Templates plugin",
 					enablePlugin: "Please enable core Templates plugin",
 				},
+				ignoredFolders: {
+					title: "Ignored Folders",
+					description:
+						"Files created in these folders will not automatically apply templates. Supports subdirectories.",
+					placeholder: "Add folders to ignore template application",
+				},
 				templateManagement: {
 					title: "Template Configuration",
 					addTemplate: "Add Template",

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -162,6 +162,12 @@ const translations: BaseMessage = {
 					placeholder: "请启用核心模板插件",
 					enablePlugin: "请启用核心模板插件",
 				},
+				ignoredFolders: {
+					title: "忽略文件夹",
+					description:
+						"在这些文件夹中创建文件时不会自动应用模板，支持子文件夹",
+					placeholder: "添加要忽略模板应用的文件夹",
+				},
 				templateManagement: {
 					title: "模板配置",
 					addTemplate: "添加模板",

--- a/src/i18n/locales/zhTW.ts
+++ b/src/i18n/locales/zhTW.ts
@@ -162,6 +162,12 @@ const translations: BaseMessage = {
 					placeholder: "請啟用核心模板插件",
 					enablePlugin: "請啟用核心模板插件",
 				},
+				ignoredFolders: {
+					title: "忽略文件夾",
+					description:
+						"在這些文件夾中創建文件時不會自動應用模板，支持子文件夾",
+					placeholder: "添加要忽略模板應用的文件夾",
+				},
 				templateManagement: {
 					title: "模板配置",
 					addTemplate: "添加模板",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -196,6 +196,11 @@ export type BaseMessage = {
 					placeholder: string;
 					enablePlugin: string;
 				};
+				ignoredFolders: {
+					title: string;
+					description: string;
+					placeholder: string;
+				};
 				templateManagement: {
 					title: string;
 					addTemplate: string;

--- a/src/toolkit/folderTemplates/components/settings/FolderTemplatesSettings.tsx
+++ b/src/toolkit/folderTemplates/components/settings/FolderTemplatesSettings.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/src/components/base/Button/Button";
 import { Input } from "@/src/components/base/Input/Input";
 import { SuggestionInput } from "@/src/components/base/Input/SuggestionInput";
+import { TagInput } from "@/src/components/base/Input/TagInput";
 import { SettingItem } from "@/src/components/base/Setting/SettingItem";
 import { useModuleConfig } from "@/src/core/hooks/useModuleConfig";
 import { useVaultSuggestions } from "@/src/core/hooks/useVaultSuggestions";
@@ -217,6 +218,28 @@ export const FolderTemplatesSettings: React.FC<
 					suggestions={folderSuggestions}
 					placeholder={t(
 						"toolkit.folderTemplates.settings.templatesFolderPath.placeholder"
+					)}
+				/>
+			</SettingItem>
+
+			<SettingItem
+				name={t(
+					"toolkit.folderTemplates.settings.ignoredFolders.title"
+				)}
+				desc={t(
+					"toolkit.folderTemplates.settings.ignoredFolders.description"
+				)}
+				collapsible={true}
+				defaultCollapsed={true}
+			>
+				<TagInput
+					values={config?.ignoredFolders || []}
+					onChange={(folders) =>
+						updateConfig({ ignoredFolders: folders })
+					}
+					suggestions={folderSuggestions}
+					placeholder={t(
+						"toolkit.folderTemplates.settings.ignoredFolders.placeholder"
 					)}
 				/>
 			</SettingItem>

--- a/src/toolkit/folderTemplates/manager/FolderTemplatesManager.ts
+++ b/src/toolkit/folderTemplates/manager/FolderTemplatesManager.ts
@@ -220,12 +220,61 @@ export class FolderTemplatesManager extends BaseManager<IFolderTemplatesModule> 
 			return null;
 		}
 
+		// 检查文件夹是否在忽略列表中
+		if (this.isFolderIgnored(folderPath)) {
+			this.logger.debug(
+				`Folder is in ignored list, skipping template application: ${folderPath}`
+			);
+			return null;
+		}
+
 		return {
 			originalFile: file,
 			folderPath,
 			templates,
 			fileName: file.basename,
 		};
+	}
+
+	/**
+	 * 检查文件夹是否在忽略列表中
+	 */
+	private isFolderIgnored(folderPath: string): boolean {
+		const ignoredFolders = this.config?.ignoredFolders || [];
+
+		if (ignoredFolders.length === 0) {
+			return false;
+		}
+
+		const normalizedFolderPath = normalizePath(folderPath);
+
+		for (const ignoredFolder of ignoredFolders) {
+			const normalizedIgnoredPath = normalizePath(ignoredFolder);
+
+			// 精确匹配
+			if (normalizedFolderPath === normalizedIgnoredPath) {
+				return true;
+			}
+
+			// 子文件夹匹配 - 检查当前文件夹是否是忽略文件夹的子目录
+			if (
+				normalizedIgnoredPath.length > 0 &&
+				normalizedFolderPath.startsWith(normalizedIgnoredPath + "/")
+			) {
+				return true;
+			}
+
+			// 特殊处理根目录
+			if (
+				(normalizedIgnoredPath === "" ||
+					normalizedIgnoredPath === "/") &&
+				normalizedFolderPath === ""
+			) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/toolkit/folderTemplates/types/config.ts
+++ b/src/toolkit/folderTemplates/types/config.ts
@@ -6,6 +6,8 @@ import {
 export interface IFolderTemplatesConfig extends IToolkitModuleConfig {
 	// 模板文件夹存放位置
 	templatesFolderPath: string;
+	// 忽略的文件夹列表，在这些文件夹中创建文件不会应用模板
+	ignoredFolders: string[];
 }
 
 export interface IFolderTemplate {
@@ -21,4 +23,5 @@ export interface IFolderTemplatesData extends IToolkitModuleData {
 export const FOLDER_TEMPLATES_DEFAULT_CONFIG: IFolderTemplatesConfig = {
 	enabled: true,
 	templatesFolderPath: "",
+	ignoredFolders: [],
 };


### PR DESCRIPTION
在文件模板模块中新增忽略文件夹”功能，允许在指定文件夹及其子目录中创建文件时不自动应用模板。
主要改动包括：
- 在 i18n（zh、en、zhTW）中添加 ignoredFolders 的文案与占位符，更新类型定义以支持新字段。
- 在配置类型中增加 ignoredFolders 字段并在默认配置中初始化为空数组。
- 在设置页面添加 TagInput，用于在 UI 中配置要忽略的文件夹（支持建议路径和多项输入）。
- 在 FolderTemplatesManager 中新增 isFolderIgnored 方法，并在处理前检查文件夹是否被忽略，若被忽略则跳过模板应用并记录调试日志。
- 添加路径归一化与精确匹配、子文件夹匹配及根目录特殊处理等逻辑，确保匹配行为符合预期。

这样做的目的是给用户提供更细粒度的控制，避免在某些文件夹（例如备份、临时或第三方目录）误触发模板，提升使用灵活性与可靠性。